### PR TITLE
ini file

### DIFF
--- a/bin/manjaro-architect.in
+++ b/bin/manjaro-architect.in
@@ -21,6 +21,7 @@ import ${LIBDIR}/util-menu.sh
 import ${LIBDIR}/util-base.sh
 import ${LIBDIR}/util-desktop.sh
 import ${LIBDIR}/util-disk.sh
+import ${LIBDIR}/ini_val.sh
 import ${DATADIR}/translations/english.trans
 
 if [[ -e /run/miso/bootmnt ]]; then

--- a/lib/ini_val.sh
+++ b/lib/ini_val.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# BASH3 Boilerplate: ini_val
+#
+# This file:
+#
+#  - Can read and write .ini files using pure bash
+#
+# Limitations:
+#
+#  - All keys inside the .ini file must be unique, regardless of the use of sections
+#
+# Usage as a function:
+#
+#  source ini_val.sh
+#  set:  ini_val data.ini connection.host 127.0.0.1
+#  read: ini_val data.ini connection.host
+#
+# Usage as a command:
+#
+#  ini_val.sh data.ini connection.host 127.0.0.1
+#
+# Based on a template by BASH3 Boilerplate v2.3.0
+# http://bash3boilerplate.sh/#authors
+#
+# The MIT License (MIT)
+# Copyright (c) 2013 Kevin van Zonneveld and contributors
+# You are not obligated to bundle the LICENSE file with your b3bp projects as long
+# as you leave these references intact in the header comments of your source files.
+
+function ini_val() {
+  local file="${1:-}"
+  local sectionkey="${2:-}"
+  local val="${3:-}"
+  local delim=" = "
+  local section=""
+  local key=""
+
+  # Split on . for section. However, section is optional
+  IFS='.' read -r section key <<< "${sectionkey}"
+  if [[ ! "${key}" ]]; then
+    key="${section}"
+    section=""
+  fi
+
+  local current
+  current=$(awk -F "${delim}" "/^${key}${delim}/ {for (i=2; i<NF; i++) printf \$i \" \"; print \$NF}" "${file}")
+
+  if [[ ! "${val}" ]]; then
+    # get a value
+    echo "${current}"
+  else
+    # set a value
+    if [[ ! "${current}" ]]; then
+      # doesn't exist yet, add
+
+      if [[ ! "${section}" ]]; then
+        # no section was given, add to bottom of file
+        echo "${key}${delim}${val}" >> "${file}"
+      else
+        # add to section
+        grep "^\[${section}\]" "${file}" || echo -e "\n[${section}]">>"${file}"
+        sed -i -e "/\[${section}\]/a ${key}${delim}${val}" "${file}"
+      fi
+    else
+      # replace existing
+      sed -i -e "/^${key}${delim}/s/${delim}.*/${delim}${val}/" "${file}"
+    fi
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+  export -f ini_val
+else
+  ini_val "${@}"
+  exit ${?}
+fi

--- a/lib/util-base.sh
+++ b/lib/util-base.sh
@@ -561,6 +561,7 @@ set_keymap() {
 
     loadkeys $KEYMAP 2>$ERR
     check_for_error "loadkeys $KEYMAP" "$?"
+    ini linux.keymap "$KEYMAP"
     # set keymap for openrc too
     echo "keymap=\"$KEYMAP\"" > /tmp/keymap
     biggest_resolution=$(head -n 1 /sys/class/drm/card*/*/modes | awk -F'[^0-9]*' '{print $1}' | awk 'BEGIN{a=   0}{if ($1>a) a=$1 fi} END{print a}')
@@ -572,6 +573,7 @@ set_keymap() {
     else
         FONT=ter-114n
     fi
+    ini linux.font "$FONT"
     echo -e "KEYMAP=${KEYMAP}\nFONT=${FONT}" > /tmp/vconsole.conf
     echo -e "consolefont=\"${FONT}\"" > /tmp/consolefont
 }
@@ -591,6 +593,7 @@ set_locale() {
     sed -i "s/#${LOCALE}/${LOCALE}/" ${MOUNTPOINT}/etc/locale.gen 2>$ERR
     arch_chroot "locale-gen" >/dev/null 2>$ERR
     check_for_error "$FUNCNAME" "$?"
+    ini linux.locale "$LOCALE"
     if [[ -e /mnt/.openrc ]]; then 
         mkdir ${MOUNTPOINT}/etc/env.d
         echo "LANG=\"${LOCALE}\"" > ${MOUNTPOINT}/etc/env.d/02locale
@@ -619,6 +622,7 @@ set_timezone() {
     if (( $? == 0 )); then
         arch_chroot "ln -sf /usr/share/zoneinfo/${ZONE}/${SUBZONE} /etc/localtime" 2>$ERR
         check_for_error "$FUNCNAME ${ZONE}/${SUBZONE}" $?
+        ini linux.zone "${ZONE}/${SUBZONE}"
     else
         return 1
     fi
@@ -632,6 +636,7 @@ set_hw_clock() {
     if [[ $(cat ${ANSWER}) != "" ]]; then
         arch_chroot "hwclock --systohc --$(cat ${ANSWER})"  2>$ERR
         check_for_error "$FUNCNAME" "$?"
+        ini linux.time "$ANSWER"
     fi
 }
 
@@ -642,6 +647,7 @@ set_hostname() {
     echo -e "#<ip-address>\t<hostname.domain.org>\t<hostname>\n127.0.0.1\tlocalhost.localdomain\tlocalhost\t$(cat \
       ${ANSWER})\n::1\tlocalhost.localdomain\tlocalhost\t$(cat ${ANSWER})" > ${MOUNTPOINT}/etc/hosts 2>$ERR
     check_for_error "$FUNCNAME"
+    ini linux.hostname "$ANSWER"
 }
 
 # Adapted and simplified from the Manjaro 0.8 and Antergos 2.0 installers


### PR DESCRIPTION
.ini file to centralize all informations given by the machine and the user.

future:
- replace small files in /tmp/
- other log / information file
- possibility to reuse it: `manjaro-architect -f "file.ini"` for not to re-enter datas ?
- possibility to use it to run developer tests
- an independence of time between menus tree and the real installation?

----------

Easy to use, all in the box

- Write: `ini system.init "openrc"`
 - Read: `init=$(ini system.init)`

The file is copied from /tmp/ to /var/log/m-a.ini when the program is closed

------------

```
[manjaro-architect]
date = 03/13/17 06:34:47
version = test#@version@

[system]
lang = fr_FR.UTF-8
init = systemd
bios = BIOS

[linux]
font = ter-114n
keymap = fr

...
```