### PR TITLE
pass params by console or file ini 

### DIFF
--- a/lib/ini_val.sh
+++ b/lib/ini_val.sh
@@ -43,7 +43,7 @@ function ini_val() {
   fi
 
   local current
-  current=$(awk -F "${delim}" "/^${key}${delim}/ {for (i=2; i<NF; i++) printf \$i \" \"; print \$NF}" "${file}")
+  current=$(awk -F "${delim}" "/^${key//\//\\\/}${delim}/ {for (i=2; i<NF; i++) printf \$i \" \"; print \$NF}" "${file}")
 
   if [[ ! "${val}" ]]; then
     # get a value

--- a/lib/util-disk.sh
+++ b/lib/util-disk.sh
@@ -235,17 +235,23 @@ select_filesystem() {
     fs_opts=""
     CHK_NUM=0
 
-    DIALOG " $_FSTitle " --menu "\n$_FSBody\n " 0 0 12 \
-      "$_FSSkip" "-" \
-        "btrfs" "mkfs.btrfs -f" \
-        "ext3" "mkfs.ext3 -q" \
-        "ext4" "mkfs.ext4 -q" \
-        "jfs" "mkfs.jfs -q" \
-        "nilfs2" "mkfs.nilfs2 -fq" \
-        "ntfs" "mkfs.ntfs -q" \
-        "reiserfs" "mkfs.reiserfs -q" \
-        "vfat" "mkfs.vfat -F32" \
-        "xfs" "mkfs.xfs -f" 2>${ANSWER} || return 1
+    local option="${ARGS[mount.${PARTITION}]}"
+    [[ -z "$option" ]] && option=$(inifile "mount.${PARTITION}")
+    if [[ -z "$option" ]]; then
+        DIALOG " $_FSTitle " --menu "\n${PARTITION}\n$_FSBody\n " 0 0 12 \
+        "$_FSSkip" "-" \
+            "btrfs" "mkfs.btrfs -f" \
+            "ext3" "mkfs.ext3 -q" \
+            "ext4" "mkfs.ext4 -q" \
+            "jfs" "mkfs.jfs -q" \
+            "nilfs2" "mkfs.nilfs2 -fq" \
+            "ntfs" "mkfs.ntfs -q" \
+            "reiserfs" "mkfs.reiserfs -q" \
+            "vfat" "mkfs.vfat -F32" \
+            "xfs" "mkfs.xfs -f" 2>${ANSWER} || return 1
+    else
+        echo "$option">${ANSWER}
+    fi
         
     case $(cat ${ANSWER}) in
         "$_FSSkip") FILESYSTEM="$_FSSkip"

--- a/lib/util-disk.sh
+++ b/lib/util-disk.sh
@@ -235,8 +235,7 @@ select_filesystem() {
     fs_opts=""
     CHK_NUM=0
 
-    local option="${ARGS[mount.${PARTITION}]}"
-    [[ -z "$option" ]] && option=$(inifile "mount.${PARTITION}")
+    local option==$(getvar "mount.${PARTITION}")
     if [[ -z "$option" ]]; then
         DIALOG " $_FSTitle " --menu "\n${PARTITION}\n$_FSBody\n " 0 0 12 \
         "$_FSSkip" "-" \
@@ -846,8 +845,7 @@ mount_partitions() {
     done
 
     # Identify and mount root
-    PARTITION="${ARGS[mount.root]}"
-    [[ -z "$PARTITION" ]] && PARTITION=$(inifile "mount.root")
+    PARTITION=$(getvar "mount.root")
     if [[ -z "$PARTITION" ]]; then
         DIALOG " $_PrepMntPart " --menu "\n$_SelRootBody\n " 0 0 12 ${PARTITIONS} 2>${ANSWER} || return 0
         PARTITION=$(cat ${ANSWER})

--- a/lib/util-disk.sh
+++ b/lib/util-disk.sh
@@ -847,12 +847,10 @@ mount_partitions() {
 
     # Identify and mount root
     PARTITION="${ARGS[mount.root]}"
+    [[ -z "$PARTITION" ]] && PARTITION=$(inifile "mount.root")
     if [[ -z "$PARTITION" ]]; then
-        PARTITION=$(inifile "mount.root")
-        if [[ -z "$PARTITION" ]]; then
-            DIALOG " $_PrepMntPart " --menu "\n$_SelRootBody\n " 0 0 12 ${PARTITIONS} 2>${ANSWER} || return 0
-            PARTITION=$(cat ${ANSWER})
-        fi
+        DIALOG " $_PrepMntPart " --menu "\n$_SelRootBody\n " 0 0 12 ${PARTITIONS} 2>${ANSWER} || return 0
+        PARTITION=$(cat ${ANSWER})
     fi
     ROOT_PART=${PARTITION}
 

--- a/lib/util-disk.sh
+++ b/lib/util-disk.sh
@@ -839,11 +839,21 @@ mount_partitions() {
         delete_partition_in_list $part
     done
 
-    # Identify and mount root
-    DIALOG " $_PrepMntPart " --menu "\n$_SelRootBody\n " 0 0 12 ${PARTITIONS} 2>${ANSWER} || return 0
-    PARTITION=$(cat ${ANSWER})
-    ROOT_PART=${PARTITION}
+echo "arg: ${ARGS[mount.root]}"
+echo "ini: $(inifile mount.root)"
 
+    # Identify and mount root
+    PARTITION="${ARGS[mount.root]}"
+    if [[ -z "$PARTITION" ]]; then
+        PARTITION=$(inifile "mount.root")
+        if [[ -z "$PARTITION" ]]; then
+            DIALOG " $_PrepMntPart " --menu "\n$_SelRootBody\n " 0 0 12 ${PARTITIONS} 2>${ANSWER} || return 0
+            PARTITION=$(cat ${ANSWER})
+        fi
+    fi
+    ROOT_PART=${PARTITION}
+#echo "format: $ROOT_PART"
+#exit
     # Format with FS (or skip) -> # Make the directory and mount. Also identify LUKS and/or LVM
     select_filesystem && mount_current_partition || return 0
 

--- a/lib/util-disk.sh
+++ b/lib/util-disk.sh
@@ -845,9 +845,6 @@ mount_partitions() {
         delete_partition_in_list $part
     done
 
-echo "arg: ${ARGS[mount.root]}"
-echo "ini: $(inifile mount.root)"
-
     # Identify and mount root
     PARTITION="${ARGS[mount.root]}"
     if [[ -z "$PARTITION" ]]; then
@@ -858,8 +855,7 @@ echo "ini: $(inifile mount.root)"
         fi
     fi
     ROOT_PART=${PARTITION}
-#echo "format: $ROOT_PART"
-#exit
+
     # Format with FS (or skip) -> # Make the directory and mount. Also identify LUKS and/or LVM
     select_filesystem && mount_current_partition || return 0
 

--- a/lib/util.sh
+++ b/lib/util.sh
@@ -158,13 +158,16 @@ get_ARGS() {
                 key="ini"
                 ARGS[$key]=$(getvalue)
                 ;;
-            --mount.root=*)
-                key="mount.root"
-                ARGS[$key]=$(getvalue)
-                ;;
             --help|-h)
                 echo -e "usage [-d|--debug] [--ini=\"file.ini\"] [ --init=openrc ]  "
                 exit 0
+                ;;
+            --*=*)
+                key="${param%=*}"
+                key="${key//-}"
+                ARGS[$key]=$(getvalue)
+                echo $key
+                #exit
                 ;;
             -*)
                 echo "${param}: not used";

--- a/lib/util.sh
+++ b/lib/util.sh
@@ -136,6 +136,16 @@ inifile() {
     ini_val "${ARGS[ini]}" "$section" 2>/dev/null
 }
 
+# read install value
+# console param, import ini, or current ini
+getvar() {
+    local value=''
+    value="${ARGS[$1]}"
+    [[ -z "$value" ]] && value=$(inifile "$1")
+    [[ -z "$value" ]] && value=$(ini "$1")
+    echo "$value"
+}
+
 # read console args , set in array ARGS global var
 get_ARGS() {
     declare key param
@@ -407,11 +417,9 @@ greeting() {
     DIALOG " $_WelTitle $VERSION " --msgbox "\n$_WelBody\n " 0 0
 
     # if params, auto load root partition
-    local PARTITION="${ARGS[mount.root]}"
-    [[ -z "$PARTITION" ]] && PARTITION=$(inifile "mount.root")
+    local PARTITION=$(getvar "mount.root")
     if [[ -n "$PARTITION" ]]; then
-        local option="${ARGS[mount.${PARTITION}]}"
-        [[ -z "$option" ]] && option=$(inifile "mount.${PARTITION}")
+        local option=$(getvar "mount.${PARTITION}")
         if [[ -n "$option" ]]; then
             mount_partitions
         fi

--- a/lib/util.sh
+++ b/lib/util.sh
@@ -166,8 +166,6 @@ get_ARGS() {
                 key="${param%=*}"
                 key="${key//-}"
                 ARGS[$key]=$(getvalue)
-                echo $key
-                #exit
                 ;;
             -*)
                 echo "${param}: not used";
@@ -407,6 +405,18 @@ check_requirements() {
 # Greet the user when first starting the installer
 greeting() {
     DIALOG " $_WelTitle $VERSION " --msgbox "\n$_WelBody\n " 0 0
+
+    # if params, auto load root partition
+    local PARTITION="${ARGS[mount.root]}"
+    [[ -z "$PARTITION" ]] && PARTITION=$(inifile "mount.root")
+    if [[ -n "$PARTITION" ]]; then
+        local option="${ARGS[mount.${PARTITION}]}"
+        [[ -z "$option" ]] && option=$(inifile "mount.${PARTITION}")
+        if [[ -n "$option" ]]; then
+            mount_partitions
+        fi
+    fi
+
 }
 
 # Originally adapted from AIS. Added option to allow users to edit the mirrorlist.


### PR DESCRIPTION
test automation

we can pass input user by console args or by particular ini file

* `--ini="test.ini" ` or
* `--mount.root="/dev/sda44" `

One function `getvar` replace `ini()` for read values

test.ini file : 

    [mount] 
    root = /dev/sda55
    /dev/sda55 = ext4

in this test, manjaro-architect dont show the dialog for choice root partition if config is pass by param or by ini file

only this dialog is rewrited for this test and choice format

```
    local PARTITION=$(getvar "mount.root")
    if [[ -z "$PARTITION" ]]; then
        DIALOG " $_PrepMntPart " --menu "\n$_SelRootBody\n " 0 0 12 ${PARTITIONS} 2>${ANSWER} || return 0
        PARTITION=$(cat ${ANSWER})
    fi
    ROOT_PART=${PARTITION}
```

Normally we should copy the contents of the ini file as input when loading into the ini file in /tmp/. Not written here