### PR TITLE
modify the way lists are handed to filter_pkgs

### DIFF
--- a/lib/util-base.sh
+++ b/lib/util-base.sh
@@ -117,8 +117,7 @@ filter_packages() {
         # Parse package list based on user input and remove parts that don't belong to pacman
         cat "$pkgs_src" >> $pkgs_target 2>$ERR
         check_for_error "$FUNCNAME" $?
-        if [[ -e $pkgs_target ]]; then
-            evaluate_openrc
+        if [[ -e /mnt/.openrc ]]; then
             # Remove any packages tagged with >systemd and remove >openrc tags
             sed -i '/>systemd/d' $pkgs_target
             sed -i 's/>openrc //g' $pkgs_target
@@ -274,7 +273,6 @@ install_base() {
         done
         echo " " >> /mnt/.base
     fi
-    echo "" > /tmp/.desktop
     filter_packages
     # remove grub
     sed -i '/grub/d' /mnt/.base

--- a/lib/util-desktop.sh
+++ b/lib/util-desktop.sh
@@ -158,13 +158,14 @@ install_manjaro_de_wm() {
         echo $displaymanager > /tmp/.display-manager
 
         # Parse package list based on user input and remove parts that don't belong to pacman
-        package_list=$(echo $PROFILES/*/$(cat /tmp/.desktop)/Packages-Desktop)
+        pkgs_src=$(echo $PROFILES/*/$(cat /tmp/.desktop)/Packages-Desktop)
+        pkgs_target=/mnt/.desktop
         filter_packages
         # remove already installed base pkgs and
         # basestrap the parsed package list to the new root
-        check_for_error "packages to install: $(cat /mnt/.base | sort | uniq | tr '\n' ' ')"
+        check_for_error "packages to install: $(grep -vf /mnt/.base /mnt/.desktop | sort | tr '\n' ' ')"
         clear
-        basestrap ${MOUNTPOINT} $(cat /mnt/.base | sort | uniq) 2>$ERR
+        basestrap ${MOUNTPOINT} $(grep -vf /mnt/.base /mnt/.desktop) 2>$ERR
         check_for_error "install desktop-pkgs" "$?" || return 1
 
         # copy the profile overlay to the new root

--- a/lib/util-desktop.sh
+++ b/lib/util-desktop.sh
@@ -149,6 +149,7 @@ install_manjaro_de_wm() {
 
     # If something has been selected, install
     if [[ $(cat /tmp/.desktop) != "" ]]; then
+        [[ -e /mnt/.openrc ]] && evaluate_openrc
         check_for_error "selected: [Manjaro-$(cat /tmp/.desktop)]"
         clear
         # Source the iso-profile

--- a/lib/util-desktop.sh
+++ b/lib/util-desktop.sh
@@ -161,6 +161,7 @@ install_manjaro_de_wm() {
         # Parse package list based on user input and remove parts that don't belong to pacman
         pkgs_src=$(echo $PROFILES/*/$(cat /tmp/.desktop)/Packages-Desktop)
         pkgs_target=/mnt/.desktop
+        echo "" > $pkgs_target
         filter_packages
         # remove already installed base pkgs and
         # basestrap the parsed package list to the new root

--- a/lib/util-menu.sh
+++ b/lib/util-menu.sh
@@ -69,6 +69,7 @@ prep_menu() {
 
         case $(cat ${ANSWER}) in
             "1") select_keymap
+                 set_keymap
                  ;;
             "2") show_devices
                  ;;

--- a/lib/util.sh
+++ b/lib/util.sh
@@ -229,13 +229,11 @@ set_language() {
     check_for_error "set LANG=${CURR_LOCALE}" $?
     ini system.lang "$CURR_LOCALE"
 
-    loadkeys $KEYMAP 2>$ERR
-    check_for_error "loadkeys $KEYMAP" "$?"
-    ini linux.keymap "$KEYMAP"
-
     setfont $FONT 2>$ERR
     check_for_error "set font $FONT" $?
     ini linux.font "$FONT"
+
+    set_keymap
 }
 
 # set locale, keymap and font and source translation file for installer
@@ -334,6 +332,12 @@ select_keymap() {
 
     DIALOG " $_VCKeymapTitle " --menu "\n$_VCKeymapBody\n " 20 40 20 ${KEYMAPS} 2>${ANSWER} || return 0
     KEYMAP=$(cat ${ANSWER})
+}
+
+set_keymap() {
+    loadkeys $KEYMAP 2>$ERR
+    check_for_error "loadkeys $KEYMAP" "$?"
+    ini linux.keymap "$KEYMAP"
 }
 
 mk_connection() {


### PR DESCRIPTION
also:
- empty desktop pkgs list when we start
- ``grep -v`` desktop pkgs against base pkgs to avoid reinstalling pkgs
- move evaluate openrc to desktop installation
- move rm grub and add nilfs-utils to base install