### PR TITLE
cat pacman log with error 255

### DIFF
--- a/lib/util-desktop.sh
+++ b/lib/util-desktop.sh
@@ -169,8 +169,11 @@ install_manjaro_de_wm() {
         # basestrap the parsed package list to the new root
         check_for_error "packages to install: $(grep -vf /mnt/.base /mnt/.desktop | sort | tr '\n' ' ')"
         clear
-        basestrap ${MOUNTPOINT} $(grep -vf /mnt/.base /mnt/.desktop) 2>$ERR
-        check_for_error "install desktop-pkgs" "$?" || return 1
+        set -o pipefail
+        basestrap ${MOUNTPOINT} $(grep -vf /mnt/.base /mnt/.desktop) 2>$ERR |& tee /tmp/basestrap.log
+        local err=$?
+        set +o pipefail
+        check_for_error "install desktop-pkgs" $err || return $err
 
         # copy the profile overlay to the new root
         echo "Copying overlay files to the new root"

--- a/lib/util-menu.sh
+++ b/lib/util-menu.sh
@@ -120,9 +120,15 @@ install_base_menu() {
                  ;;
             "3") install_base
                  ;;
-            "4") check_base && {
-                    install_manjaro_de_wm_pkg || DIALOG " $_InstBseTitle " --msgbox "\n$_InstFail\n " 0 0
-                 }
+            "4") check_base && install_manjaro_de_wm_pkg
+                    local err=$?
+                    if [[ $err > 0 ]]; then
+                        DIALOG " $_InstBseTitle " --msgbox "\n$_InstFail\n " 0 0;
+                        if [[ $err == 255 ]]; then
+                            cat /tmp/basestrap.log
+                            read -n1 -s
+                        fi
+                    fi
                  ;;
             "5") install_bootloader
                  ;;


### PR DESCRIPTION
in install base and install DE
redirect pacman output in log file, and show only if we have error 255 after error dialog


one test result :  

```
                                              Error ───────────┐
                                   │                           │  
                                   │ [install basepkgs][255]   │  
                                   ├───────────────────────────┤  
                                   │       <Accepter>          │  
                                   └───────────────────────────┘  
                                     ┌──── Install Base ──────┐
                                     │                        │  
                                     │ Installation failed.   │  
                                     │                        │  
                                     ├────────────────────────┤  
                                     │       <Accepter>       │  
                                     └────────────────────────┘  

==> Creating install root at /mnt
  -> Installing packages to /mnt
:: Synchronizing package databases...
error: failed to update core (unable to lock database)
error: failed to update extra (unable to lock database)
error: failed to update community (unable to lock database)
error: failed to update multilib (unable to lock database)
error: failed to synchronize any databases
error: failed to init transaction (unable to lock database)
error: could not lock database: File exists
  if you're sure a package manager is not already
  running, you can remove /mnt/var/lib/pacman/db.lck
==> ERROR: Failed to install packages to new root

```

I have the impression that basetrap() does not return any error output :grimacing: And always 255 ?