### PR TITLE
Uncapitalize EFI to efi

### DIFF
--- a/lib/util-config.sh
+++ b/lib/util-config.sh
@@ -56,10 +56,10 @@ edit_configs() {
         options+=( $i "refind_linux.conf" )
         functions+=( "nano ${MOUNTPOINT}/boot/refind_linux.conf" )
     fi    
-    if [[ -e ${MOUNTPOINT}${UEFI_MOUNT}/EFI/refind/refind_linux.conf ]]; then
+    if [[ -e ${MOUNTPOINT}${UEFI_MOUNT}/efi/refind/refind_linux.conf ]]; then
         ((i++))
         options+=( $i "refind.conf" )
-        functions+=( "nano ${MOUNTPOINT}${UEFI_MOUNT}/EFI/refind/refind.conf" )
+        functions+=( "nano ${MOUNTPOINT}${UEFI_MOUNT}/efi/refind/refind.conf" )
     fi    
     if [[ -e ${MOUNTPOINT}${UEFI_MOUNT}/loader/loader.conf ]]; then
         ((i++))


### PR DESCRIPTION
This patch uncapitalizes `EFI` to `efi` - the Architect disk setup uses `/boot/efi`, and so this inconsistency causes the installation of GRUB to break.

It is also okay to go the other way around - that is, the disk setup uses `/boot/EFI`, but seeing as `/boot/efi` is used in several other areas here, it is easiest to perform this 2 line change as opposed to many more.

Apologies for not being able to sign this patch - I am editing this on a machine with fresh M-A installation which provided me a half-broken GNOME (because of the `[255]` issue with installing GNOME in the full variant) and spent too much time not understanding why that and GRUB was not installing properly until now.