### PR TITLE
Use the -E flag of sudo command

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -30,7 +30,7 @@ done
 
 echo "updating the installer ..."
 sleep 1
-sudo pacman -Sy manjaro-architect --noconfirm
+sudo -E pacman -Sy manjaro-architect --noconfirm
 
 echo "launching Manjaro Architect ..."
-sudo manjaro-architect "$@"
+sudo -E manjaro-architect "$@"


### PR DESCRIPTION
If the user sets environment variables before running the setup script. It will no longer be available when running the sudo command.
This can be useful for users who are behind a proxy for example.